### PR TITLE
Fix docker-compose defaults and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ sh
 mkdir -p /opt/excel-mcp/calamine_mcp
 cd /opt/excel-mcp
 2. Add Project Files
-Copy the project files (as shown in the structure above) into their respective directories.
+Copy **all** files from this repository into `/opt/excel-mcp`.
+The `Dockerfile` must be located next to `docker-compose.yml` so that the
+image can be built correctly.
 
 3. Prepare Excel Files Directory
 Ensure the directory to be mounted as a volume exists. For example:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,11 @@
 # Этот файл полностью соответствует вашему запросу.
+version: "3.8"
 services:
   ssp-excel-mcp:
     # Указываем, что нужно собирать образ из текущей директории
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
     ports:
       - "8000:8000"
     volumes:
@@ -13,8 +16,8 @@ services:
       - EXCEL_FILES_PATH=/app/backend/data/uploads
       # UID и GID для запуска процесса от имени вашего пользователя,
       # чтобы избежать проблем с правами на смонтированный volume
-      - UID=1000
-      - GID=1000
+      - UID=${UID:-1000}
+      - GID=${GID:-1000}
     # Запускаем контейнер от имени пользователя, указанного в environment
-    user: "${UID}:${GID}"
+    user: "${UID:-1000}:${GID:-1000}"
     restart: always


### PR DESCRIPTION
## Summary
- clarify that the Dockerfile must be placed next to `docker-compose.yml`
- provide defaults for UID/GID in compose file
- specify compose version and explicit build context

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68749656e8d48320989f884201324757