### PR TITLE
Handle new fastmcp import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Workbooks are cached to speed up repeated reads.
 
 Easy Deployment:
 Containerized with Docker and Docker Compose.
+The code now automatically supports both old and new versions of
+``fastmcp``. If you encounter import errors related to ``Mcp`` or ``Mq``,
+make sure the library is up to date.
 
 🗂 Project Structure
 bash

--- a/calamine_mcp/server.py
+++ b/calamine_mcp/server.py
@@ -9,7 +9,14 @@ import logging
 import os
 from typing import Any, Dict, List
 
-from fastmcp import Mcp, Mq
+# fastmcp recently changed its public API, moving the main classes
+# under the ``server`` submodule.  To remain compatible with both the
+# old and the new versions we attempt the old style import first and
+# fall back to the new location if needed.
+try:  # pragma: no cover - import paths depend on installed version
+    from fastmcp import Mcp, Mq
+except ImportError:  # pragma: no cover - for new fastmcp versions
+    from fastmcp.server import Mcp, Mq
 
 from .workbook import Workbook
 


### PR DESCRIPTION
## Summary
- support both old and new fastmcp APIs by falling back to `fastmcp.server`
- mention the compatibility note in the README

## Testing
- `python -m py_compile calamine_mcp/server.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68749c97f42483209e65d94961e83746