### PR TITLE
Resolve merge conflicts and support fastmcp imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Workbooks are cached to speed up repeated reads.
 
 Easy Deployment:
 Containerized with Docker and Docker Compose.
+The server automatically supports old and new versions of ``fastmcp``.
+It tries several known import locations and will scan the package at runtime
+to locate ``Mcp`` and ``Mq``. If you still encounter import errors, verify
+that your ``fastmcp`` installation is up to date.
 
 🗂 Project Structure
 bash

--- a/calamine_mcp/server.py
+++ b/calamine_mcp/server.py
@@ -9,7 +9,50 @@ import logging
 import os
 from typing import Any, Dict, List
 
-from fastmcp import Mcp, Mq
+# fastmcp has changed its public API multiple times.  To stay compatible
+# we try several known locations and finally fall back to scanning the
+# package for the required classes at runtime.
+from importlib import import_module
+import pkgutil
+
+
+def _import_fastmcp():  # pragma: no cover - depends on installed fastmcp
+    """Return the ``Mcp`` and ``Mq`` classes from whatever fastmcp version is
+    installed."""
+
+    candidates = [
+        "fastmcp",
+        "fastmcp.server",
+        "fastmcp.server.api",
+        "fastmcp.api",
+    ]
+
+    for mod_name in candidates:
+        try:
+            mod = import_module(mod_name)
+        except Exception:  # pragma: no cover - optional modules may miss
+            continue
+        if hasattr(mod, "Mcp") and hasattr(mod, "Mq"):
+            return mod.Mcp, mod.Mq
+
+    try:
+        import fastmcp
+        for pkg in pkgutil.walk_packages(fastmcp.__path__, fastmcp.__name__ + "."):
+            try:
+                mod = import_module(pkg.name)
+            except Exception:  # pragma: no cover - ignore broken imports
+                continue
+            if hasattr(mod, "Mcp") and hasattr(mod, "Mq"):
+                return mod.Mcp, mod.Mq
+    except Exception:
+        pass
+
+    raise ImportError(
+        "Unable to locate 'Mcp' and 'Mq' in fastmcp. Please verify the library version."
+    )
+
+
+Mcp, Mq = _import_fastmcp()
 
 from .workbook import Workbook
 


### PR DESCRIPTION
## Summary
- merge latest `main` into working branch
- clarify fastmcp compatibility note in README
- keep dynamic import logic for `Mcp`/`Mq`

## Testing
- `python -m py_compile calamine_mcp/server.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68749c97f42483209e65d94961e83746